### PR TITLE
Add InMemoryProtocol and NullProtocol

### DIFF
--- a/models/protocols/InMemoryProtocol.cfc
+++ b/models/protocols/InMemoryProtocol.cfc
@@ -31,7 +31,7 @@ component extends="cbmailservices.models.AbstractProtocol" singleton accessors="
      * @callback A callback function to check against each mail item.
      */
 	public boolean function hasMessage( required function callback ) {
-		return arraySome( variables.mail, arguments.callback );
+		return arrayFilter( variables.mail, arguments.callback ).len() > 0;
 	}
 
     /**

--- a/models/protocols/InMemoryProtocol.cfc
+++ b/models/protocols/InMemoryProtocol.cfc
@@ -1,0 +1,44 @@
+component extends="cbmailservices.models.AbstractProtocol" singleton accessors="true" {
+
+	property name="mail" type="array";
+
+	/**
+	 * Initialize the InMemory protocol
+	 *
+	 * @properties A map of configuration properties for the protocol
+	 */
+	public InMemoryProtocol function init( struct properties = {} ) {
+		super.init( argumentCollection = arguments );
+		variables.mail = [];
+		return this;
+	}
+
+	/**
+	 * Log the message as sent.
+	 *
+	 * @payload The payload to deliver
+	 */
+	public struct function send( required cbmailservices.models.Mail payload ) {
+		variables.mail.append( arguments.payload.getMemento() );
+		return { "error": false, "errorArray": [] };
+	}
+
+    /**
+     * Check if a given message has been sent by passing in a callback.
+     * Each message will be checked against the callback.
+     * If one message passes the callback, this method will return true.
+     * 
+     * @callback A callback function to check against each mail item.
+     */
+	public boolean function hasMessage( required function callback ) {
+		return arraySome( variables.mail, arguments.callback );
+	}
+
+    /**
+     * Resets the in-memory array.
+     */
+	public void function reset() {
+		variables.mail = [];
+	}
+
+}

--- a/models/protocols/NullProtocol.cfc
+++ b/models/protocols/NullProtocol.cfc
@@ -1,0 +1,12 @@
+component extends="cbmailservices.models.AbstractProtocol" singleton accessors="true" {
+
+	/**
+	 * Ignore the sent message and return a successful response.
+	 *
+	 * @payload The payload to deliver
+	 */
+	public struct function send( required cbmailservices.models.Mail payload ) {
+		return { "error": false, "errorArray": [] };
+	}
+
+}

--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,8 @@ The ColdBox Mail services module will allow you to send email the OO way in
 multiple protocols for many environments.  The supported protocols are:
 
 * **CFMail** - Traditional `cfmail` sending
+* **Null** - Ignores emails sent to it.
+* **InMemory** - Store email mementos in an array. Perfect for testing.
 * **Files** - Write emails to disk
 * **Postmark API** - Send via the PostMark Service (https://postmarkapp.com/)
 
@@ -103,6 +105,8 @@ getAdditionalInfoItem( key );
 The mail services can send mail via different protocols.  The available protocols are:
 
 * `CFMailProtocol`
+* `NullProtocol`
+* `InMemoryProtocol`
 * `FileProtocol`
 * `PostmarkProtocol`
 
@@ -116,7 +120,19 @@ protocol = {
         filePath = "logs",
         autoExpand = true
     }
-}
+};
+
+// NullProtocol
+protocol = {
+    class = "cbmailservices.models.protocols.NullProtocol",
+    properties = {}
+};
+
+// InMemoryProtocol
+protocol = {
+    class = "cbmailservices.models.protocols.InMemoryProtocol",
+    properties = {}
+};
 
 // PostMark
 protocol = {
@@ -124,7 +140,7 @@ protocol = {
     properties = {
         APIKey = ""
     }
-}
+};
 ```
 
 ### Custom Protocols

--- a/test-harness/tests/specs/protocols/InMemoryProtocolTest.cfc
+++ b/test-harness/tests/specs/protocols/InMemoryProtocolTest.cfc
@@ -49,4 +49,30 @@
         expect( messages[ 4 ] ).toBe( payloadD.getMemento() );
     }
 
+    public void function testHasMessage() {
+        variables.protocol.reset();
+        var sentPayload = getMockBox().createMock( className = "cbmailservices.models.Mail" ).init()
+            .config( from = "info@coldbox.org", to = "sent@coldbox.org", type = "html" );
+        sentPayload.setBodyTokens( { "name": "Luis Majano", "time": dateformat( now(), "full" ) } );
+        sentPayload.setBody( "<h1>Hello @name@, how are you today?</h1>  <p>Today is the <b>@time@</b>.</p> <br/><br/><a href=""http://www.coldbox.org"">ColdBox Rules!</a>" );
+        sentPayload.setSubject( "Mail SENT" );
+        variables.protocol.send( sentPayload );
+
+        var unsentPayload = getMockBox().createMock( className = "cbmailservices.models.Mail" ).init()
+            .config( from = "info@coldbox.org", to = "unsent@coldbox.org", type = "html" );
+        unsentPayload.setBodyTokens( { "name": "Luis Majano", "time": dateformat( now(), "full" ) } );
+        unsentPayload.setBody( "<h1>Hello @name@, how are you today?</h1>  <p>Today is the <b>@time@</b>.</p> <br/><br/><a href=""http://www.coldbox.org"">ColdBox Rules!</a>" );
+        unsentPayload.setSubject( "Mail NOT SENT" );
+
+        expect( variables.protocol.hasMessage( function( mail ) {
+            return mail.from == sentPayload.getMemento().from &&
+                mail.to == sentPayload.getMemento().to;
+        } ) ).toBeTrue( "hasMessage should return true for message that was sent." );
+        
+        expect( variables.protocol.hasMessage( function( mail ) {
+            return mail.from == unsentPayload.getMemento().from &&
+                mail.to == unsentPayload.getMemento().to;
+        } ) ).toBeFalse( "hasMessage should return true for message that was not sent." );
+    }
+
 }

--- a/test-harness/tests/specs/protocols/InMemoryProtocolTest.cfc
+++ b/test-harness/tests/specs/protocols/InMemoryProtocolTest.cfc
@@ -1,0 +1,52 @@
+﻿component extends="coldbox.system.testing.BaseTestCase" {
+    
+    this.loadColdBox = false;
+
+    public void function setup() {
+        // Create a mock instance of the protocol.
+        variables.protocol = getMockBox().createMock( className = "cbmailservices.models.protocols.InMemoryProtocol" ).init( {} );
+    }
+
+    public void function testSend() {
+        // 1:Mail with No Params
+        var payloadA = getMockBox().createMock( className = "cbmailservices.models.Mail" ).init()
+            .config( from = "info@coldbox.org", to = "automation@coldbox.org", type = "html" );
+        payloadA.setBodyTokens( { "name": "Luis Majano", "time": dateformat( now(), "full" ) } );
+        payloadA.setBody( "<h1>Hello @name@, how are you today?</h1>  <p>Today is the <b>@time@</b>.</p> <br/><br/><a href=""http://www.coldbox.org"">ColdBox Rules!</a>" );
+        payloadA.setSubject( "Mail NO Params-Hello Luis" );
+        variables.protocol.send( payloadA );
+
+
+        // 2:Mail with params
+        var payloadB = getMockBox().createMock( className = "cbmailservices.models.Mail" ).init()
+            .config( from = "info@coldbox.org", to = "automation@coldbox.org", subject = "Mail With Params - Hello Luis" );
+        payloadB.setBody( "Hello This is my great unit test" );
+        payloadB.addMailParam( name = "Disposition-Notification-To", value = "info@coldbox.org" );
+        payloadB.addMailParam( name = "Importance", value = "High" );
+        variables.protocol.send( payloadB );
+
+        // 3:Mail multi-part no params
+        var payloadC = getMockBox().createMock( className = "cbmailservices.models.Mail" ).init()
+            .config( from = "info@coldbox.org", to = "automation@coldbox.org", subject = "Mail MultiPart No Params - Hello Luis" );
+        payloadC.addMailPart( type = "text", body = "You are reading this message as plain text, because your mail reader does not handle it." );
+        payloadC.addMailPart( type = "html", body = "This is the body of the message." );
+        variables.protocol.send( payloadC );
+
+        // 4:Mail multi-part with params
+        var payloadD = getMockBox().createMock( className = "cbmailservices.models.Mail" ).init()
+            .config( from = "info@coldbox.org", to = "automation@coldbox.org", subject = "Mail MultiPart With Params - Hello Luis" );
+        payloadD.addMailPart( type = "text", body = "You are reading this message as plain text, because your mail reader does not handle it.");
+        payloadD.addMailPart( type = "html", body = "This is the body of the message.");
+        payloadD.addMailParam( name = "Disposition-Notification-To", value = "info@coldbox.org" );
+        variables.protocol.send( payloadD );
+
+        var messages = variables.protocol.getMail();
+        expect( messages ).toBeArray();
+        expect( messages ).toHaveLength( 4 );
+        expect( messages[ 1 ] ).toBe( payloadA.getMemento() );
+        expect( messages[ 2 ] ).toBe( payloadB.getMemento() );
+        expect( messages[ 3 ] ).toBe( payloadC.getMemento() );
+        expect( messages[ 4 ] ).toBe( payloadD.getMemento() );
+    }
+
+}

--- a/test-harness/tests/specs/protocols/NullProtocolTest.cfc
+++ b/test-harness/tests/specs/protocols/NullProtocolTest.cfc
@@ -1,0 +1,46 @@
+﻿component extends="coldbox.system.testing.BaseTestCase" {
+    
+    this.loadColdBox = false;
+
+    public void function setup() {
+        // Create a mock instance of the protocol.
+        variables.protocol = getMockBox().createMock( className = "cbmailservices.models.protocols.InMemoryProtocol" ).init( {} );
+    }
+
+    public void function testSend() {
+        // 1:Mail with No Params
+        var payloadA = getMockBox().createMock( className = "cbmailservices.models.Mail" ).init()
+            .config( from = "info@coldbox.org", to = "automation@coldbox.org", type = "html" );
+        payloadA.setBodyTokens( { "name": "Luis Majano", "time": dateformat( now(), "full" ) } );
+        payloadA.setBody( "<h1>Hello @name@, how are you today?</h1>  <p>Today is the <b>@time@</b>.</p> <br/><br/><a href=""http://www.coldbox.org"">ColdBox Rules!</a>" );
+        payloadA.setSubject( "Mail NO Params-Hello Luis" );
+        variables.protocol.send( payloadA );
+
+
+        // 2:Mail with params
+        var payloadB = getMockBox().createMock( className = "cbmailservices.models.Mail" ).init()
+            .config( from = "info@coldbox.org", to = "automation@coldbox.org", subject = "Mail With Params - Hello Luis" );
+        payloadB.setBody( "Hello This is my great unit test" );
+        payloadB.addMailParam( name = "Disposition-Notification-To", value = "info@coldbox.org" );
+        payloadB.addMailParam( name = "Importance", value = "High" );
+        variables.protocol.send( payloadB );
+
+        // 3:Mail multi-part no params
+        var payloadC = getMockBox().createMock( className = "cbmailservices.models.Mail" ).init()
+            .config( from = "info@coldbox.org", to = "automation@coldbox.org", subject = "Mail MultiPart No Params - Hello Luis" );
+        payloadC.addMailPart( type = "text", body = "You are reading this message as plain text, because your mail reader does not handle it." );
+        payloadC.addMailPart( type = "html", body = "This is the body of the message." );
+        variables.protocol.send( payloadC );
+
+        // 4:Mail multi-part with params
+        var payloadD = getMockBox().createMock( className = "cbmailservices.models.Mail" ).init()
+            .config( from = "info@coldbox.org", to = "automation@coldbox.org", subject = "Mail MultiPart With Params - Hello Luis" );
+        payloadD.addMailPart( type = "text", body = "You are reading this message as plain text, because your mail reader does not handle it.");
+        payloadD.addMailPart( type = "html", body = "This is the body of the message.");
+        payloadD.addMailParam( name = "Disposition-Notification-To", value = "info@coldbox.org" );
+        variables.protocol.send( payloadD );
+
+        // if we get here without errors, it works fine.
+    }
+
+}


### PR DESCRIPTION
Two new protocols:
+ The `NullProtocol` ignores all calls to it.
+ The `InMemoryProtocol` stores mail mementos in an internal array. This can be useful for testing to check that mail was sent.  It also includes a handle `hasMessage` method which takes a predicate callback and checks it against each sent mail.  A `reset` method is included for use inside tests.