### PR TITLE
Add Subject to the validation failure error message

### DIFF
--- a/models/Mail.cfc
+++ b/models/Mail.cfc
@@ -191,7 +191,7 @@ component accessors="true" {
 	}
 
 	/**
-	 * Validate that the basic fields of from, to, and body are set for sending mail
+	 * Validate that the basic fields of from, to, subject, and body are set for sending mail
 	 */
 	boolean function validate(){
 		if (

--- a/models/MailService.cfc
+++ b/models/MailService.cfc
@@ -269,7 +269,7 @@ component accessors="true" singleton threadsafe {
 			arguments.mail.setResults( {
 				"error"    : true,
 				"messages" : [
-					"Please check the basic mail fields of To, From and Body as they are empty. To: #arguments.mail.getTo()#, From: #arguments.mail.getFrom()#, Body Len = #arguments.mail.getBody().length()#."
+					"Please check the basic mail fields of To, From, Subject and Body as they are empty. To: #arguments.mail.getTo()#, From: #arguments.mail.getFrom()#, Subject Len = #arguments.mail.getSubject().length()#, Body Len = #arguments.mail.getBody().length()#."
 				]
 			} )
 			log.error( "Mail object does not validate.", arguments.mail.getConfig() );


### PR DESCRIPTION
The `validate` function checks `To`, `From`, `Subject`, and `Body`: https://github.com/coldbox-modules/cbmailservices/blob/development/models/Mail.cfc#L196 

In the case where we properly passed through `To`, `From`, and `Body` (and had an empty `Subject`) it was difficult to understand why it was failing without also pointing out that `Subject Len = 0`.