### PR TITLE
Add reasonable defaults for commonly accessed mail fields

### DIFF
--- a/models/Mail.cfc
+++ b/models/Mail.cfc
@@ -47,6 +47,9 @@ component accessors="true" {
 			"from"           : "",
 			"fromName"       : "",
 			"to"             : "",
+			"cc"             : "",
+			"bcc"             : "",
+			"subject"             : "",
 			"additionalInfo" : {}
 		};
 


### PR DESCRIPTION
Getters only work if there is a variables.config key in existence. Without this change, getting a subject, cc or bb with the dynamic getting would blow up.

Seems like we should handle nicer defaults.
Maybe we should actually build in a nice list of guaranteed getters or something... instead of relying on the config it was initialized with.

I assume it's ok to have empty values of these keys.
If someone doesn't pass in a subject right now, it would error instead of failing validation as well. 

This should help make it more resilient. 
