### PR TITLE
parseTokens error with complex data  when using send-grid-protocol with cbmailservices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode
+.idea
 
 .artifacts/**
 .tmp/**

--- a/models/MailService.cfc
+++ b/models/MailService.cfc
@@ -377,7 +377,7 @@ component accessors="true" singleton threadsafe {
 		var key         = "";
 
 		// Do not process tokens if using dynamic template (send-grid-protocol)
-		if(arguments.mail.getType() == "template") return;
+		if( arguments.mail.getType() == "template" ) return;
 
 		// Check mail parts for content
 		if ( arrayLen( mailparts ) ) {

--- a/models/MailService.cfc
+++ b/models/MailService.cfc
@@ -376,6 +376,9 @@ component accessors="true" singleton threadsafe {
 		var tokenMarker = getTokenMarker();
 		var key         = "";
 
+		// Do not process tokens if using dynamic template (send-grid-protocol)
+		if(arguments.mail.getType() == "template") return;
+
 		// Check mail parts for content
 		if ( arrayLen( mailparts ) ) {
 			// Loop over mail parts


### PR DESCRIPTION
# Description

SendGrid allows you to use handlebars to render data when using dynamic templates (email type "template"). If you try to send complex (nested data) it will cause an error when parsing tokens:

As an example, here are a set of bodyTokens for a SendGrid dynamic template:

```
{
  "contact_name": "Smith, John Alfred",
  "account_name": "Awesome Company.",
  "parts": [
    {
      "end_use": "Mil/Aero",
      "quantity": 5,
      "sku": "1013",
      "end_user": "Awesome Company",
      "item_type": "EVB",
      "status_type": "Start"
    }
  ],
  "subject": "A new request has been created for Awesome Company",
  "priority_type": "High"
}
```
## Issues

If you attempt to pass complex data  you will receive an error that "complex object types cannot be converted to simple values." Since tokens are handled at send grid, skip processing if the email type is "template" and just send the values across as-is. In this case the `body` value will just be a templateID, there is no need for token replacement.

## Type of change

- [ X ] Bug Fix
- [ X ] Improvement

## Testing
CommandBox> testbox run --noVerbose
Executing tests http://localhost:50745/test-harness/tests/runner.cfm?&recurse=true&reporter=json&verbose=false please wait...

╔═════════════════════════════════════════════════════════════════════╗
║ Passed  ║ Failed  ║ Errored ║ Skipped ║ Bundles ║ Suites  ║ Specs   ║
╠═════════════════════════════════════════════════════════════════════╣
║ 50      ║ 0       ║ 0       ║ 0       ║ 11      ║ 12      ║ 50      ║
╚═════════════════════════════════════════════════════════════════════╝

TestBox         v5.0.0
CFML Engine     Lucee v5.3.10.120
Duration        767ms
Labels          ---

