### PR TITLE
BCC Only should be allowed

### DIFF
--- a/models/Mail.cfc
+++ b/models/Mail.cfc
@@ -217,7 +217,7 @@ component accessors="true" {
 	boolean function validate(){
 		if (
 			variables.config.from.len() eq 0 OR
-			variables.config.to.len() eq 0 OR
+			(variables.config.to.len() eq 0 AND variables.config.bcc.len() eq 0) OR
 			variables.config.subject.len() eq 0 OR
 			( variables.config.body.len() eq 0 AND arrayLen( variables.config.mailParts ) EQ 0 )
 		) {


### PR DESCRIPTION
Emails dispatched to BCC only should be allowed so that systems can send the same email to multiple recipients blindly
